### PR TITLE
Use any markup in Share Component

### DIFF
--- a/src/Share.jsx
+++ b/src/Share.jsx
@@ -87,16 +87,7 @@ export default class Share extends Component {
     const { className, buttonClassName, iconClassName, icon } = this.props;
 
     return (
-      <div className={className}>
-        <button
-          type="button"
-          className={buttonClassName}
-          onClick={this.handleClick}
-        >
-          {icon ? <i className={iconClassName} /> : null}
-          {this.props.children}
-        </button>
-      </div>
+      React.cloneElement(this.props.children, {onClick: this.handleClick})
     );
   }
 }


### PR DESCRIPTION
instead of put  inside `<div>` and  `<button>`, share component can use any child

USAGE
```
<Share href="https://www.google.com">
  <svg>...</svg>
</Share>
```