### PR TITLE
Add string proptype to comments

### DIFF
--- a/src/Comments.jsx
+++ b/src/Comments.jsx
@@ -12,7 +12,10 @@ export default class Comments extends Parser {
     href: PropTypes.string,
     numPosts: PropTypes.number.isRequired,
     orderBy: PropTypes.string.isRequired,
-    width: PropTypes.number.isRequired,
+    width: PropTypes.oneOfType([
+      PropTypes.number.isRequired,
+      PropTypes.string.isRequired
+    ]),
     colorScheme: PropTypes.string.isRequired,
     children: PropTypes.node,
   };


### PR DESCRIPTION
According to the [documentation](https://developers.facebook.com/docs/plugins/comments), the width attribute could be either a number or percentage.

Actually, instead of adding string as an alternative propType, should I add a new boolean for indicating if the component is fluid. If it is fluid, we can just add '%' right before rendering.

connect to #8 