### PR TITLE
Fix for "skin must be one of the following values light dark" issue

### DIFF
--- a/src/Comments.jsx
+++ b/src/Comments.jsx
@@ -47,6 +47,7 @@ export default class Comments extends Parser {
         data-href={href}
         data-order-by={orderBy}
         data-width={width}
+        data-skin={colorScheme}
       >
         {children}
       </div>


### PR DESCRIPTION
In attempting to use the comments component I ran into an issue where it was rendering the text "skin must be one of the following values light dark" for just a moment then going blank.

I added a data-skin attribute which fixes the issue. I left the colorScheme attribute in place for backward compatibility and to not change the api.

Please disregard this if you have a different fix already in the works.