### PR TITLE
Remove not required data attribute to setting FB page plugin

### DIFF
--- a/src/Page.jsx
+++ b/src/Page.jsx
@@ -75,7 +75,3 @@ Page.defaultProps = {
   className: undefined,
   onParse: undefined,
 };
-
-Page.contextTypes = {
-  facebook: PropTypes.object.isRequired,
-};

--- a/src/Page.jsx
+++ b/src/Page.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Parser from './Parser';
 import getCurrentHref from './utils/getCurrentHref';
 
-export default function Page(props, context) {
+export default function Page(props) {
   const {
     className,
     style,
@@ -20,14 +20,11 @@ export default function Page(props, context) {
     onParse,
   } = props;
 
-  const appId = context.facebook && context.facebook.props.appId;
-
   return (
     <Parser className={className} onParse={onParse}>
       <div
         className="fb-page"
         style={style}
-        data-appID={appId}
         data-tabs={tabs}
         data-hide-cover={hideCover}
         data-show-facepile={showFacepile}


### PR DESCRIPTION
I have same issue with #51  warning message alert in React 16. So I remove not required data attribute to setting FB page plugin.