### PR TITLE
Making it compatible with all browsers + Google Fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "test": "jest ./src/",
     "test:coverage": "jest --coverage ./src/",
     "test:watch": "jest --watch ./src/",
-    "build-browser": "cross-env BABEL_ENV=browser babel ./src --out-dir ./lib --source-maps --copy-files",
-    "build-module": "cross-env BABEL_ENV=module babel ./src --out-dir ./module --source-maps --copy-files",
-    "build-node": "babel ./src --out-dir ./dist --source-maps --copy-files",
+    "build-browser": "rm -rf lib && cross-env BABEL_ENV=browser babel ./src --out-dir ./lib",
+    "build-module": "rm -rf module && cross-env BABEL_ENV=module babel ./src --out-dir ./module --source-maps --copy-files",
+    "build-node": "rm -rf dist && babel ./src --out-dir ./dist --source-maps --copy-files",
     "build": "npm run build-node && npm run build-browser && npm run build-module",
     "eslint": "node ./node_modules/eslint/bin/eslint.js --ext .js,.jsx ./src"
   },

--- a/src/Facebook.js
+++ b/src/Facebook.js
@@ -1,4 +1,7 @@
-import debug from 'debug';
+// Referring to built file so its compatible with all browsers
+// Especially Phantom.js. Before this fix, Google Fetch would fail
+// reading a SPA app. This fixes it.
+import debug from '../node_modules/debug/dist/debug';
 import LoginStatus from './constants/LoginStatus';
 
 const log = debug('react-facebook:facebook');


### PR DESCRIPTION
**Problem:**

I used this library to add facebook comments on my site - Thanks @seeden.
But then immediately I found that with this change [Google Fetch](https://www.google.com/webmasters/tools/googlebot-fetch) could not render my site.

**Culprit**
Dug deep and found that the "debug" module source `src/index.js` is not compatible for such things.

**Solution**
If we use the built version inside `dist/debug.js` that would work.

**I have fixed it**
I hope this works and you can merge it into the next release.