### PR TITLE
Fix 'Token is undefined' bug in Login component

### DIFF
--- a/src/Facebook.js
+++ b/src/Facebook.js
@@ -126,8 +126,13 @@ export default class Facebook {
     return this.process('getAuthResponse');
   }
 
-  async getTokenDetail() {
-    const response = await this.getLoginStatus();
+  async getTokenDetail(response = null) {
+    if (response !== null) {
+      return response.authResponse
+    }
+
+    response = await this.getLoginStatus();
+    
     if (response.status === LoginStatus.CONNECTED && response.authResponse) {
       return response.authResponse;
     }
@@ -139,8 +144,8 @@ export default class Facebook {
     return this.api('/me', Method.GET, params);
   }
 
-  async getTokenDetailWithProfile(params) {
-    const tokenDetail = await this.getTokenDetail();
+  async getTokenDetailWithProfile(params, response = null) {
+    const tokenDetail = await this.getTokenDetail(response);
     const profile = await this.getProfile(params);
 
     return {

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -67,7 +67,7 @@ class Login extends Component<Props> {
           throw new Error('Unauthorized user');
         }
 
-        const data = await api.getTokenDetailWithProfile({ fields });
+        const data = await api.getTokenDetailWithProfile({ fields }, response);
 
         if (onCompleted) {
           await onCompleted({


### PR DESCRIPTION
# Problem
As mentioned in #117 there is an annoying bug inside the `Login` component. If you click/handle the first time it will always (at least, never went well on the first try at our side) return the error 'Token is undefined'.

From reading the source code and trying things out I've figured out that the flow is like this:

* `api.login` is called from the `Login` component. It will return a 'connected ' response. 
* `api.getTokenDetailWithProfile` is called from `Login`. Inside that method, first `getTokenDetail` is called. Inside the `getTokenDetail` method `getLoginStatus` is called. That will return a bad response, something like `response.authResponse: null` and return that to `getTokenDetail`.
* Because of that, `getTokenDetail` will throw the error `Token is undefined`.

It's probably because the user is not authenticated yet at the FB side so `getLoginStatus` will return null. So I thought, why not use the response of the `api.login` you just did? You don't have to check the login status if you logged in like a few seconds before right?

# Solution
I've added the response from the `api.login` call as a param to the `getTokenDetailWithProfile` call. I've made sure that the default value is `null` in `Facebook.js`, both in `getTokenDetailWithProfile` as in `getTokenDetail`. I will pass down the response to `getTokenDetail`.

Inside this method, I will check the response and if the response is not null I will skip the call `getLoginStatus` and return the response directly, the one coming from the `api.login` call. Otherwise, `getLoginStatus` gets called and the method will continue just as before.

Check out the code, and let me know if this is the right approach so we can fix this problem asap ✌️