### PR TITLE
Don't call onready on an unmounted component

### DIFF
--- a/src/Initialize.jsx
+++ b/src/Initialize.jsx
@@ -17,13 +17,18 @@ class Initialize extends Component<Props> {
   };
 
   componentDidMount() {
+    this._ismounted = true;
     this.prepare();
+  }
+
+  componentWillUnmount() {
+    this._ismounted = false;
   }
 
   async prepare() {
     const { onReady, handleInit } = this.props;
     const api = await handleInit();
-    if (onReady) {
+    if (onReady && this._ismounted) {
       onReady(api);
     }
   }


### PR DESCRIPTION
fixes issues https://github.com/seeden/react-facebook/issues/113