### PR TITLE
Changed SDK to support customerchat

### DIFF
--- a/src/Facebook.js
+++ b/src/Facebook.js
@@ -68,7 +68,7 @@ export default class Facebook {
       js.id = 'facebook-jssdk';
       js.async = true;
       js.defer = true;
-      js.src = `https://${domain}/${language}/sdk${debug ? '/debug' : ''}.js`;
+      js.src = `https://${domain}/${language}/sdk${debug ? '/debug' : ''}/xfbml.customerchat.js`;
 
       window.document.body.appendChild(js);
     });

--- a/src/Facebook.js
+++ b/src/Facebook.js
@@ -68,7 +68,7 @@ export default class Facebook {
       js.id = 'facebook-jssdk';
       js.async = true;
       js.defer = true;
-      js.src = `https://${domain}/${language}/sdk${debug ? '/debug' : ''}/xfbml.customerchat.js`;
+      js.src = `https://${domain}/${language}/sdk/xfbml.customerchat${debug ? '/debug' : ''}.js`;
 
       window.document.body.appendChild(js);
     });

--- a/src/Facebook.js
+++ b/src/Facebook.js
@@ -18,6 +18,7 @@ export default class Facebook {
       language: 'en_US',
       frictionlessRequests: false,
       debug: false,
+      chatSupport: false,
       ...options,
     };
 
@@ -44,6 +45,7 @@ export default class Facebook {
         domain,
         language,
         debug,
+        chatSupport,
         ...restOptions
       } = this.options;
 
@@ -68,7 +70,7 @@ export default class Facebook {
       js.id = 'facebook-jssdk';
       js.async = true;
       js.defer = true;
-      js.src = `https://${domain}/${language}/sdk/xfbml.customerchat${debug ? '/debug' : ''}.js`;
+      js.src = `https://${domain}/${language}/sdk${chatSupport ? '/xfbml.customerchat' : ''}${debug ? '/debug' : ''}.js`;
 
       window.document.body.appendChild(js);
     });

--- a/src/FacebookProvider.jsx
+++ b/src/FacebookProvider.jsx
@@ -18,6 +18,7 @@ type Props = {
   children?: Node,
   wait?: boolean,
   debug: boolean,
+  chatSupport: boolean,
 };
 
 type State = {
@@ -36,6 +37,7 @@ export default class Facebook extends Component<Props, State> {
     children: undefined,
     wait: false,
     debug: false,
+    chatSupport: false,
   };
 
   state: State = {
@@ -72,6 +74,7 @@ export default class Facebook extends Component<Props, State> {
         frictionlessRequests,
         wait,
         debug,
+        chatSupport,
       } = this.props;
 
       api = new FB({
@@ -85,6 +88,7 @@ export default class Facebook extends Component<Props, State> {
         frictionlessRequests,
         wait,
         debug,
+        chatSupport,
       });
     }
 


### PR DESCRIPTION
PR is related to #99 and solves the problem where the customer chat plugin is not rendered in combination with other Facebook plugins.

According to Facebook's developer docs (https://developers.facebook.com/docs/messenger-platform/discovery/customer-chat-plugin/sdk):

> Starting on January 8th, 2019, you will no longer be able to request the Customer Chat Plugin with the following URL: https://connect.facebook.net/en_US/sdk.js. If you do not switch to the URL stated below, the plugin will not render on your website.

> https://connect.facebook.net/en_US/sdk/xfbml.customerchat.js requests a version of the Facebook Javascript SDK that includes the Customer Chat SDK. With this URL, you will still be able to access all of the Facebook Javascript SDK plus all features of the Customer Chat SDK.