### PR TITLE
Update MessageUs.jsx to support data-size (html)

### DIFF
--- a/src/MessageUs.jsx
+++ b/src/MessageUs.jsx
@@ -39,6 +39,7 @@ class MessageUs extends PureComponent<Props> {
         page_id={pageId}
         color={color}
         size={size}
+        data-size={size}
       >
         {children}
       </div>


### PR DESCRIPTION
according to https://developers.facebook.com/docs/messenger-platform/reference/web-plugins#message_us%2F
in html5 we need to use the size attribute instead of data-size