### PR TITLE
Uncaught Promise rejection error when closing Share popup

### DIFF
--- a/src/Facebook.js
+++ b/src/Facebook.js
@@ -84,6 +84,7 @@ export default class Facebook {
     return new Promise((resolve, reject) => {
       fb[method](...before, (response) => {
         if (!response) {
+          if (method === 'ui') return;
           reject(new Error('Response is undefined'));
         } else if (response.error) {
           const { code, type, message } = response.error;


### PR DESCRIPTION
Right now, the FB API is returning `undefined` when you close the `ui` method popup (that's being used for the Share component). Normally, they return `{authResponse: undefined, status: "unknown"}` or something like that. I've created a small PR that will early return if the FB API is returning `undefined` with the method  `ui`. This way, you won't get an (annoying) error for 'just' closing the popup.

Not sure if this is the right approach, but this is just a proposal.  This issue was mentioned [here](https://github.com/seeden/react-facebook/issues/136).