### PR TITLE
Allow passing of extras option to FB.login()

### DIFF
--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -21,6 +21,7 @@ export default function LoginButton(props: LoginButton) {
     authType,
     rerequest,
     reauthorize,
+    extras,
     onError,
     onSuccess,
     ...rest
@@ -40,6 +41,7 @@ export default function LoginButton(props: LoginButton) {
         authType,
         rerequest,
         reauthorize,
+        extras,
       });
 
       onSuccess?.(response);

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -9,6 +9,7 @@ export type LoginOptions = {
   authType?: string[];
   rerequest?: boolean;
   reauthorize?: boolean;
+  extras?: Record<string, any>;
 };
 
 export default function useLogin() {

--- a/src/utils/Facebook.ts
+++ b/src/utils/Facebook.ts
@@ -19,6 +19,7 @@ export type LoginOptions = {
   authType?: string[];
   rerequest?: boolean;
   reauthorize?: boolean;
+  extras?: Record<string, any>;
 };
 declare global {
   interface Window { 
@@ -173,11 +174,12 @@ export default class Facebook {
   }
 
   async login(options: LoginOptions) {
-    const { scope, authType = [], returnScopes, rerequest, reauthorize } = options;
+    const { scope, authType = [], returnScopes, rerequest, reauthorize, extras } = options;
     const loginOptions: {
       return_scopes?: boolean;
       auth_type?: string;
       scope?: string;
+      extras?: Record<string, any>;
     } = {
       scope,
     };
@@ -196,6 +198,10 @@ export default class Facebook {
 
     if (authType.length) {
       loginOptions.auth_type = authType.join(',');
+    }
+
+    if (extras) {
+      loginOptions.extras = extras;
     }
 
     return this.process<LoginResponse>(Namespace.LOGIN, [], [loginOptions]);


### PR DESCRIPTION
`FB.login()` function allows passing of an `extras` option as well. It is not part of the usual login flow, but is needed for some specific flows like the [embedded signup flow here](https://developers.facebook.com/docs/whatsapp/embedded-signup/embed-the-flow#step-2--set-up-facebook-login)

This PR allows passing of this non-mandatory `extras` option.